### PR TITLE
feat: add clean PR merge script

### DIFF
--- a/scripts/merge_clean_only.sh
+++ b/scripts/merge_clean_only.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+OWNER="Balizero1987"; REPO="zantara_bridge"
+PR_IDS=$(gh pr list -R "$OWNER/$REPO" --search "head:codex/" --json number,state -q '.[] | select(.state=="OPEN") | .number')
+for PR in $PR_IDS; do
+  S=$(gh pr view "$PR" -R "$OWNER/$REPO" --json mergeable,mergeStateStatus -q '.mergeable+" "+.mergeStateStatus')
+  if [ "$S" = "MERGEABLE CLEAN" ] || [ "$S" = "MERGEABLE clean" ]; then
+    gh pr merge "$PR" -R "$OWNER/$REPO" --squash --delete-branch --admin || true
+  fi
+done


### PR DESCRIPTION
## Summary
- add utility script to merge `codex/*` PRs only when mergeable and clean

## Testing
- `gh run list -R "Balizero1987/zantara_bridge" --event repository_dispatch --limit 10` *(fails: requires authentication)*
- `gh pr list -R "Balizero1987/zantara_bridge" --search "head:codex/" --limit 50` *(fails: requires authentication)*
- `./scripts/merge_clean_only.sh` *(fails: requires authentication)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba68cb4e488330bcb5b01a1e082f24