### PR TITLE
ci: add merge-clean workflow

### DIFF
--- a/.github/workflows/merge-clean.yml
+++ b/.github/workflows/merge-clean.yml
@@ -1,0 +1,69 @@
+name: Merge Clean Codex PRs
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-clean:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge all clean codex/* PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            // lista PR codex/* aperte
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100
+            });
+
+            // helper per ricalcolare mergeability (GitHub la calcola async)
+            async function getWithMergeable(number, tries=6) {
+              for (let i=0; i<tries; i++) {
+                const { data } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+                if (data.mergeable_state && data.mergeable !== null) return data;
+                await new Promise(r => setTimeout(r, 2000)); // attesa 2s
+              }
+              const { data } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+              return data;
+            }
+
+            let merged = [];
+            for (const pr of prs) {
+              if (!pr.head.ref.startsWith('codex/')) continue;
+              const data = await getWithMergeable(pr.number);
+              core.info(`PR #${pr.number} ${pr.title} mergeable=${data.mergeable} state=${data.mergeable_state}`);
+
+              // solo PR "MERGEABLE" e mergeable_state "clean"
+              const state = (data.mergeable_state || '').toLowerCase();
+              if (data.mergeable === true && state === 'clean') {
+                try {
+                  await github.rest.pulls.merge({
+                    owner, repo, pull_number: pr.number,
+                    merge_method: 'squash'
+                  });
+                  // elimina branch remoto
+                  await github.rest.git.deleteRef({
+                    owner, repo, ref: `heads/${pr.head.ref}`
+                  }).catch(()=>{});
+                  merged.push(pr.number);
+                  core.notice(`Merged PR #${pr.number} (${pr.head.ref})`);
+                } catch (e) {
+                  core.warning(`Merge failed PR #${pr.number}: ${e.message}`);
+                }
+              } else {
+                core.info(`Skip PR #${pr.number} (state=${state})`);
+              }
+            }
+
+            core.summary
+              .addHeading('Merge Clean Codex PRs')
+              .addRaw(`Merged: ${merged.length ? merged.join(', ') : 'none'}`)
+              .write();


### PR DESCRIPTION
## Summary
- add workflow to merge only clean codex/* PRs

## Testing
- `gh workflow run merge-clean.yml -R Balizero1987/zantara_bridge` *(fails: authentication required)*
- `gh run list -R Balizero1987/zantara_bridge --workflow "Merge Clean Codex PRs" --limit 3` *(fails: authentication required)*
- `gh pr list -R Balizero1987/zantara_bridge --search "head:codex/" --limit 50` *(fails: authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6aebf694833080510ff5007b4a7b