### PR TITLE
fix: allow building docx features

### DIFF
--- a/src/notes.ts
+++ b/src/notes.ts
@@ -143,7 +143,7 @@ export async function generateReportDocx(ownerRaw: string, dateStr = ymd(), summ
   const notes = await listNotes(owner, dateStr);
   const title = reportTitle(owner, dateStr);
 
-  const paragraphs: Paragraph[] = [
+  const paragraphs = [
     new Paragraph({ text: `Report – ${owner} – ${dateStr}`, heading: HeadingLevel.HEADING_1 }),
   ];
   if (summaryText) {

--- a/src/types/docx.d.ts
+++ b/src/types/docx.d.ts
@@ -1,0 +1,1 @@
+declare module 'docx';


### PR DESCRIPTION
## Summary
- stub docx module types for ts compiler
- remove Paragraph type annotation

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc62346ae48330940a68f723c031f3