### PR TITLE
QA: add skeleton for 50 plugin tests (manifest/notes/chat/docgen)

### DIFF
--- a/tests/50_plugin_smoke.sh
+++ b/tests/50_plugin_smoke.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${URL:?set URL}"; : "${OWNER:=riri}"
+# KEY da Secret Manager se non presente:
+if [ -z "${KEY:-}" ]; then
+  KEY="$(gcloud secrets versions access latest --secret=ZANTARA_PLUGIN_API_KEY --project involuted-box-469105-r0 | tr -d '\n\r')" || true
+fi
+fail=0
+run(){ name="$1"; shift; echo "== $name"; if ! bash -c "$*"; then echo "!! FAIL: $name"; fail=$((fail+1)); fi; }
+# TODO: Codex – implementa 50 run ... (ID: M1..M6, N1..N18, C1..C16, D1..D10)
+exit $fail

--- a/tests/50_plugin_tests.http
+++ b/tests/50_plugin_tests.http
@@ -1,0 +1,4 @@
+# TODO (Codex): 50 richieste HTTP in formato VS Code/JetBrains
+# @URL = https://zantara-chat-v3-1064094238013.asia-southeast2.run.app
+# @KEY = (in runtime)
+# @OWNER = riri

--- a/tests/README_tests.md
+++ b/tests/README_tests.md
@@ -1,0 +1,7 @@
+# Plugin QA: 50 alternative
+
+| ID | Route | Input | Expected code | Expected JSON path |
+|----|------|-------|----------------|--------------------|
+| M1 | /.well-known/ai-plugin.json | – | 200 | `.schema_version=="v1"` |
+| M2 | /.well-known/openapi.json   | – | 200 | `.info.title` contains "ZANTARA" |
+| …  | … | … | … | … |


### PR DESCRIPTION
## Summary
- add bash script scaffold for 50 plugin smoke tests
- add HTTP file skeleton for 50 plugin requests
- add README table describing test cases

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be0263953c8330b86889d51c963b5b